### PR TITLE
Do not hardcode AMDGPU-Pro version inside ebuilds

### DIFF
--- a/sys-kernel/amdgpu-pro-dkms/amdgpu-pro-dkms-16.30.3.315407-r1.ebuild
+++ b/sys-kernel/amdgpu-pro-dkms/amdgpu-pro-dkms-16.30.3.315407-r1.ebuild
@@ -5,11 +5,11 @@
 EAPI=5
 
 MULTILIB_COMPAT=( abi_x86_{32,64} )
-inherit eutils linux-info multilib-build unpacker
+inherit eutils linux-info multilib-build unpacker versionator
 
 DESCRIPTION="AMD GPU-Pro kernel module for Radeon Evergreen (HD5000 Series) and newer chipsets"
 HOMEPAGE="http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Beta-Driver-for-Vulkan-Release-Notes.aspx"
-BUILD_VER=16.30.3-315407
+BUILD_VER=$(replace_version_separator 3 '-')
 SRC_URI="https://www2.ati.com/drivers/beta/amdgpu-pro_${BUILD_VER}.tar.xz"
 
 RESTRICT="fetch strip"

--- a/x11-drivers/amdgpu-pro/amdgpu-pro-16.30.3.315407-r1.ebuild
+++ b/x11-drivers/amdgpu-pro/amdgpu-pro-16.30.3.315407-r1.ebuild
@@ -6,14 +6,11 @@ EAPI=6
 
 MULTILIB_COMPAT=( abi_x86_{32,64} )
 #inherit eutils linux-info multilib-build unpacker
-inherit multilib-build unpacker
+inherit multilib-build unpacker versionator
 
 DESCRIPTION="AMD precompiled drivers for Radeon Evergreen (HD5000 Series) and newer chipsets"
 HOMEPAGE="http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Beta-Driver-for-Vulkan-Release-Notes.aspx"
-PKG_VER=16.30.3
-PKG_REV=315407
-PKG_VER_STRING=${PKG_VER}-${PKG_REV}
-BUILD_VER=${PKG_VER}.${PKG_REV}
+PKG_VER_STRING=$(replace_version_separator 3 '-')
 SRC_URI="https://www2.ati.com/drivers/beta/amdgpu-pro_${PKG_VER_STRING}.tar.xz"
 
 RESTRICT="fetch strip"
@@ -41,7 +38,7 @@ RDEPEND="
 "
 DEPEND="
 	=x11-libs/libdrm-2.4.66-r1
-	=sys-kernel/amdgpu-pro-dkms-${BUILD_VER}-r1
+	=sys-kernel/amdgpu-pro-dkms-${PV}-r1
 "
 
 S="${WORKDIR}"

--- a/x11-libs/libdrm/libdrm-2.4.66-r1.ebuild
+++ b/x11-libs/libdrm/libdrm-2.4.66-r1.ebuild
@@ -6,16 +6,13 @@ EAPI=5
 
 #XORG_MULTILIB=yes
 #inherit xorg-2 unpacker
-inherit multilib-build unpacker
+inherit multilib-build unpacker versionator
 
 DESCRIPTION="X.Org libdrm library (amdgpu-pro binary)"
 #HOMEPAGE="https://dri.freedesktop.org/"
 #DESCRIPTION="AMD precompiled drivers for Radeon Evergreen (HD5000 Series) and newer chipsets"
 HOMEPAGE="http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Beta-Driver-for-Vulkan-Release-Notes.aspx"
-PKG_VER=16.30.3
-PKG_REV=315407
-PKG_VER_STRING=${PKG_VER}-${PKG_REV}
-BUILD_VER=${PKG_VER}.${PKG_REV}
+PKG_VER_STRING=$(replace_version_separator 3 '-')
 ARCH_NAME="amdgpu-pro_${PKG_VER_STRING}.tar.xz"
 SRC_URI="https://www2.ati.com/drivers/beta/${ARCH_NAME}"
 


### PR DESCRIPTION
The version number should always come from the ebuild name. We can use
replace_version_separator from versionator.eclass to transform PV from
the Gentoo form of x.y.z.foo to the AMD form of x.y.z-foo.
